### PR TITLE
Also build components with C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+idf_build_set_property(CXX_COMPILE_OPTIONS -std=gnu++23 APPEND)
+
 set(EXTRA_COMPONENT_DIRS
     esp_boost
     esp-protocols/components


### PR DESCRIPTION
Many components fail to build otherwise, because they use `std::to_underlying`.